### PR TITLE
fix xss on sandbox

### DIFF
--- a/symfony/bundles/SandboxBundle/Resources/views/fake_sms/thread.html.twig
+++ b/symfony/bundles/SandboxBundle/Resources/views/fake_sms/thread.html.twig
@@ -98,10 +98,10 @@
 
         responsiveChatPush(
             '.chat',
-            '{{ message.name|e('js') }}',
-            '{{ message.direction|e('js') }}',
-            '{{ message.createdAt|date('d/m/Y H:i') }}',
-            nl2br('{{ message.content|e('js') }}')
+            '{{ message.name|e('html')|e('js') }}',
+            '{{ message.direction|e('html')|e('js') }}',
+            '{{ message.createdAt|e('html')|date('d/m/Y H:i') }}',
+            nl2br('{{ message.content|e('html')|e('js') }}')
         );
 
         {% endfor %}


### PR DESCRIPTION
`|e('js')` is escaping in the javascript context, but if we are reinserting those data in the dom, we should also `|e('html')`.

I'm also creating a ticket in order to check other escapings.

